### PR TITLE
Oppdateringer og andre endringer (sikkerhet).

### DIFF
--- a/download/ffmpeg/ffmpeg-8.1.1-chromium_method-1.patch
+++ b/download/ffmpeg/ffmpeg-8.1.1-chromium_method-1.patch
@@ -1,0 +1,1 @@
+ffmpeg-8.1-chromium_method-1.patch

--- a/download/ffmpeg/ffmpeg-chromium_method-1.patch
+++ b/download/ffmpeg/ffmpeg-chromium_method-1.patch
@@ -1,0 +1,1 @@
+ffmpeg-8.1.1-chromium_method-1.patch

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,25 @@
     -->
 
     <listitem>
+      <para>8. mai 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[zeckma] - GLib: 2.88.0 -&gt; 2.88.1 (sikkerhet). Fikser
+          <ulink url="&glfs-issues;/431">#431</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - libgpg-error: 1.60 -&gt; 1.61 (sikkerhet).
+          Se BLFS billett
+          <ulink url="&blfs-ticket-root;23264">#23264</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - FFmpeg: 8.1 -&gt; 8.1.1 (sikkerhet). Fikser
+          <ulink url="&glfs-issues;/437">#437</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>5. mai 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -41,7 +41,7 @@
 <!ENTITY duktape-version              "2.7.0">
 <!ENTITY glib2-major                   "2">
 <!ENTITY glib2-minor                   "88">
-<!ENTITY glib2-version                 "&glib2-major;.&glib2-minor;.0">
+<!ENTITY glib2-version                 "&glib2-major;.&glib2-minor;.1">
 <!ENTITY gi-major                      "1">
 <!ENTITY gi-minor                      "&gi-major;.86">
 <!ENTITY gobject-introspection-version "&gi-minor;.0">
@@ -266,7 +266,7 @@
 <!-- STEAM -->
 
 <!ENTITY xdg-user-dirs-version        "0.20">
-<!ENTITY libgpg-error-version         "1.60">
+<!ENTITY libgpg-error-version         "1.61">
 <!ENTITY steam-version                "1.0.0.85">
 
 
@@ -297,7 +297,7 @@
 <!ENTITY libvpx-version               "1.16.0">
 <!ENTITY x264-version                 "20250815">
 <!ENTITY x265-version                 "4.2">
-<!ENTITY ffmpeg-version               "8.1">
+<!ENTITY ffmpeg-version               "8.1.1">
 <!ENTITY gstreamer10-version          "1.28.2">  <!-- Even minors only -->
 <!ENTITY gst10-plugins-base-version   "&gstreamer10-version;">
 <!ENTITY gst10-plugins-good-version   "&gstreamer10-version;">

--- a/shareddeps/api/libclc.xml
+++ b/shareddeps/api/libclc.xml
@@ -43,8 +43,12 @@
       <bridgehead renderas="sect3">libclc Avhengigheter</bridgehead>
 
       <para role="required">
-        <xref linkend="llvm"/> (med Clang) og
-        <xref linkend="spirv-llvm-translator"/>
+        <xref linkend="llvm"/> (med Clang)
+      </para>
+
+      <para role="recommended">
+        <xref linkend="spirv-llvm-translator"/> (påkrevd av noen Mesa
+        drivere)
       </para>
 
     </sect2>

--- a/shareddeps/drivers-mesa/mesa.xml
+++ b/shareddeps/drivers-mesa/mesa.xml
@@ -97,8 +97,9 @@
         </listitem>
         <listitem>
           <para>
-            <xref linkend="libclc"/> (påkrevd for Intel Iris Gallium3D og
-            Nouveau Vulkan)
+            <xref linkend="libclc"/> (med <xref
+            linkend="spirv-llvm-translator"/>;
+            påkrevd for Iris Gallium3D og Nouveau Vulkan)
           </para>
         </listitem>
         <listitem>
@@ -127,15 +128,15 @@
         </listitem>
         <listitem>
           <para>
-            <xref linkend="llvm"/> (kreves for r300, r600 og radeonsi 
-            driverne og LLVMpipe programvarens rasteriseringsprogram; Clang i LLVM 
-            er nødvendig for Swrast Vulkan)
+            <xref linkend="llvm"/> (påkrevd for r300, r600, RadeonSI
+            og LLVMPipe Gallium3D; Clang i LLVM er
+            påkrevd for SWRast Vulkan)
           </para>
         </listitem>
         <listitem>
           <para>
             <xref linkend="vulkan-sdk"/> (påkrevd for Vulkan og Zink
-            Gallium3D støtte)
+            Gallium3D)
           </para>
         </listitem>
         <listitem>

--- a/wine/gs/ffmpeg.xml
+++ b/wine/gs/ffmpeg.xml
@@ -44,7 +44,7 @@
       <listitem>
         <para>
           Nødvendig oppdatering:
-          <ulink url="&dl-root;/ffmpeg/ffmpeg-&ffmpeg-version;-chromium_method-1.patch"/>
+          <ulink url="&dl-root;/ffmpeg/ffmpeg-chromium_method-1.patch"/>
         </para>
       </listitem>
     </itemizedlist>
@@ -123,7 +123,7 @@
       <!-- qtwebengine -->
     </para>
 
-<screen><userinput remap="pre">patch -Np1 -i ../ffmpeg-&ffmpeg-version;-chromium_method-1.patch</userinput></screen>
+<screen><userinput remap="pre">patch -Np1 -i ../ffmpeg-chromium_method-1.patch</userinput></screen>
 
 <!--
     <para>


### PR DESCRIPTION
GLib:         2.88.0 -> 2.88.1 (sikkerhet).
libgpg-error: 1.60   -> 1.61   (sikkerhet).
FFmpeg:       8.1    -> 8.1.1  (sikkerhet).
libclc:       Degradere SPIRV-LLVM-Translator til Anbefalt.