### PR TITLE
Oppdater flere pakker, fiks libglvnd.

### DIFF
--- a/download/libglvnd/libglvnd-v1.7.0-ext_device-1.patch
+++ b/download/libglvnd/libglvnd-v1.7.0-ext_device-1.patch
@@ -1,0 +1,150 @@
+Submitted by:            Zeckma
+Date:                    2026-06-13
+Initial Package Version: 1.7.0
+Origin:                  Upstream,
+                         https://gitlab.freedesktop.org/glvnd/libglvnd/-/merge_requests/298
+Upstream Status:         Not merged yet
+Description:             Exposes all of the device EGL extensions if just one
+                         is advertised. Necessary for drivers that don't expose
+                         all three, but rather one or two. Required for
+                         Mesa-less.
+
+diff --git a/src/EGL/libegl.c b/src/EGL/libegl.c
+index 2a62f092ca2723cc42a38408423e6be789207391..311f3a071d4e9bea40770cfd9c9b78874c6d5b5a 100644
+--- a/src/EGL/libegl.c
++++ b/src/EGL/libegl.c
+@@ -59,9 +59,6 @@
+  */
+ static const char *SUPPORTED_CLIENT_EXTENSIONS =
+     "EGL_EXT_platform_base"
+-    " EGL_EXT_device_base"
+-    " EGL_EXT_device_enumeration"
+-    " EGL_EXT_device_query"
+     " EGL_EXT_platform_device"
+ 
+     // FIXME: Include the other platform extensions here to make testing
+@@ -872,6 +869,8 @@ static char *GetClientExtensionString(void)
+     struct glvnd_list *vendorList = __eglLoadVendors();
+     __EGLvendorInfo *vendor;
+     char *result = NULL;
++    EGLBoolean supportsDeviceEnum = EGL_FALSE;
++    EGLBoolean supportsDeviceQuery = EGL_FALSE;
+ 
+     // First, find the union of all available vendor libraries. Start with an
+     // empty string, then merge the extension string from every vendor library.
+@@ -890,6 +889,9 @@ static char *GetClientExtensionString(void)
+                 return NULL;
+             }
+         }
++
++        supportsDeviceEnum = supportsDeviceEnum || vendor->supportsDeviceEnum;
++        supportsDeviceQuery = supportsDeviceQuery || vendor->supportsDeviceQuery;
+     }
+ 
+     // Next, take the intersection of the client extensions from the vendors
+@@ -902,6 +904,26 @@ static char *GetClientExtensionString(void)
+         return NULL;
+     }
+ 
++    // Add the appropriate set of device extensions.
++    if (supportsDeviceEnum) {
++        result = UnionExtensionStrings(result, "EGL_EXT_device_enumeration");
++        if (result == NULL) {
++            return NULL;
++        }
++    }
++    if (supportsDeviceQuery) {
++        result = UnionExtensionStrings(result, "EGL_EXT_device_query");
++        if (result == NULL) {
++            return NULL;
++        }
++    }
++    if (supportsDeviceEnum && supportsDeviceQuery) {
++        result = UnionExtensionStrings(result, "EGL_EXT_device_base");
++        if (result == NULL) {
++            return NULL;
++        }
++    }
++
+     glvnd_list_for_each_entry(vendor, vendorList, entry) {
+         const char *vendorString = NULL;
+         if (vendor->eglvc.getVendorString != NULL) {
+@@ -963,7 +985,7 @@ static EGLBoolean QueryVendorDevices(__EGLvendorInfo *vendor, EGLint max_devices
+     EGLint vendorCount = 0;
+     EGLint i;
+ 
+-    if (!vendor->supportsDevice) {
++    if (!vendor->supportsDeviceEnum) {
+         return EGL_TRUE;
+     }
+ 
+diff --git a/src/EGL/libeglvendor.c b/src/EGL/libeglvendor.c
+index acece59708ab03b9623c5b0ecd39839b6a43ced5..3cfb7065f74fe7535c295aa0e506176904f4c3fe 100644
+--- a/src/EGL/libeglvendor.c
++++ b/src/EGL/libeglvendor.c
+@@ -385,6 +385,7 @@ static void CheckVendorExtensionString(__EGLvendorInfo *vendor, const char *str)
+ {
+     static const char NAME_DEVICE_BASE[] = "EGL_EXT_device_base";
+     static const char NAME_DEVICE_ENUM[] = "EGL_EXT_device_enumeration";
++    static const char NAME_DEVICE_QUERY[] = "EGL_EXT_device_query";
+     static const char NAME_PLATFORM_DEVICE[] = "EGL_EXT_platform_device";
+     static const char NAME_MESA_PLATFORM_GBM[] = "EGL_MESA_platform_gbm";
+     static const char NAME_KHR_PLATFORM_GBM[] = "EGL_KHR_platform_gbm";
+@@ -397,10 +398,24 @@ static void CheckVendorExtensionString(__EGLvendorInfo *vendor, const char *str)
+         return;
+     }
+ 
+-    if (!vendor->supportsDevice) {
+-        if (IsTokenInString(str, NAME_DEVICE_BASE, sizeof(NAME_DEVICE_BASE) - 1, " ")
+-                || IsTokenInString(str, NAME_DEVICE_ENUM, sizeof(NAME_DEVICE_ENUM) - 1, " ")) {
+-            vendor->supportsDevice = EGL_TRUE;
++    if (!vendor->supportsDeviceEnum || !vendor->supportsDeviceQuery) {
++        /*
++         * EGL_EXT_device_base is equivalent to supporting both
++         * EGL_EXT_device_enumeration and EGL_EXT_device_query.
++         *
++         * Keep track of both so that we know which to include when we
++         * construct the client extension string.
++         */
++        if (IsTokenInString(str, NAME_DEVICE_BASE, sizeof(NAME_DEVICE_BASE) - 1, " ")) {
++            vendor->supportsDeviceEnum = EGL_TRUE;
++            vendor->supportsDeviceQuery = EGL_TRUE;
++        } else {
++            if (IsTokenInString(str, NAME_DEVICE_ENUM, sizeof(NAME_DEVICE_ENUM) - 1, " ")) {
++                vendor->supportsDeviceEnum = EGL_TRUE;
++            }
++            if (IsTokenInString(str, NAME_DEVICE_QUERY, sizeof(NAME_DEVICE_QUERY) - 1, " ")) {
++                vendor->supportsDeviceQuery = EGL_TRUE;
++            }
+         }
+     }
+ 
+@@ -443,10 +458,12 @@ static void CheckVendorExtensions(__EGLvendorInfo *vendor)
+     }
+ 
+     if (vendor->staticDispatch.queryDevicesEXT == NULL) {
+-        vendor->supportsDevice = EGL_FALSE;
++        vendor->supportsDeviceEnum = EGL_FALSE;
+     }
+ 
+-    if (!vendor->supportsDevice) {
++    if (!vendor->supportsDeviceEnum && !vendor->supportsDeviceQuery) {
++        // If we don't have either of the device extensions, then there's no
++        // way to get an EGLDeviceEXT handle from this vendor.
+         vendor->supportsPlatformDevice = EGL_FALSE;
+     }
+ }
+diff --git a/src/EGL/libeglvendor.h b/src/EGL/libeglvendor.h
+index 443f285e20ff86100d7134158d740f791f710a10..bc3fdef18b831869cb44ef258e9bea573d01f86c 100644
+--- a/src/EGL/libeglvendor.h
++++ b/src/EGL/libeglvendor.h
+@@ -29,7 +29,8 @@ struct __EGLvendorInfoRec {
+     EGLBoolean supportsGL;
+     EGLBoolean supportsGLES;
+ 
+-    EGLBoolean supportsDevice;
++    EGLBoolean supportsDeviceEnum;
++    EGLBoolean supportsDeviceQuery;
+     EGLBoolean supportsPlatformDevice;
+     EGLBoolean supportsPlatformGbm;
+     EGLBoolean supportsPlatformX11;

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,54 @@
     -->
 
     <listitem>
+      <para>13. juni 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[zeckma] - NSS: 3.124 -&gt; 3.125.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Cbindgen: 0.29.3 -&gt; 0.29.4. Fikser
+          <ulink url="&glfs-issues;/474">#474</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Wayland-Protocols: 1.48 -&gt; 1.49. Fikser
+          <ulink url="&glfs-issues;/475">#475</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - OpenCL-SDK: 2025.07.22 -&gt; 2026.05.29. Fikser
+          <ulink url="&glfs-issues;/476">#476</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - NVIDIA: 595.71.05 -&gt; 610.43.02. Fikser
+          <ulink url="&glfs-issues;/477">#477</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - CUDA: 13.2.1 -&gt; 13.3.0. Fikser
+          <ulink url="&glfs-issues;/473">#473</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - NVIDIA-r580: 580.159.03 -&gt; 580.159.04.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - sdl2-compat: 2.32.68 -&gt; 2.32.70. Fikser
+          <ulink url="&glfs-issues;/478">#478</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - GStreamer-Suite: 1.28.3 -&gt; 1.28.4 (sikkerhet).
+          Se BLFS billett
+          <ulink url="&blfs-ticket-root;23444">#23444</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Wine: 11.10 -&gt; 11.11.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - libglvnd: Legg til en oppdatering for å annonsere 
+          alle EGL enhetsutvidelser.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>4. juni 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -20,7 +20,7 @@
 <!ENTITY libtasn1-version             "4.21.0">
 <!ENTITY nspr-version                 "4.39">
 <!ENTITY nss-major                    "3">
-<!ENTITY nss-minor                    "124">
+<!ENTITY nss-minor                    "125">
 <!ENTITY nss-dir                      "&nss-major;_&nss-minor;">
 <!ENTITY nss-version                  "&nss-major;.&nss-minor;">
 <!ENTITY p11-kit-version              "0.26.2">
@@ -63,7 +63,7 @@
 <!ENTITY rustc-openssl                "a6debf535674c9a073f455158743e6ba094cf1b4">
 <!ENTITY rustc-openssl-nice           "0.10.78">
 <!ENTITY rustc-openssl-sys-nice       "0.9.114">
-<!ENTITY cbindgen-version             "0.29.3">
+<!ENTITY cbindgen-version             "0.29.4">
 <!ENTITY rust-bindgen-version         "0.72.1">
 <!ENTITY mako-version                 "1.3.12">
 <!ENTITY cython-version               "3.2.5">
@@ -151,7 +151,7 @@
 <!ENTITY libinput-version             "1.31.3">
 <!-- Wayland -->
 <!ENTITY wayland-version              "1.25.0">
-<!ENTITY wayland-protocols-version    "1.48">
+<!ENTITY wayland-protocols-version    "1.49">
 <!-- Graphics APIs -->
 <!ENTITY libglvnd-version             "1.7.0">
 <!ENTITY glu-version                  "9.0.3">
@@ -161,7 +161,7 @@
 <!ENTITY libdrm-version               "2.4.134">
 <!ENTITY libgbm-version               "1.0.7">
 <!ENTITY libva-version                "2.23.0">
-<!ENTITY opencl-version               "2025.07.22">
+<!ENTITY opencl-version               "2026.05.29">
 <!ENTITY libclc-version               "&llvm-version;">
 <!-- Graphics Drivers - Preliminaries -->
 <!ENTITY pciutils-version             "3.15.0">
@@ -180,20 +180,24 @@
 <!ENTITY nvidia-vaapi-driver-version  "0.0.17">
 <!ENTITY nvidia-beta                  "<superscript>BETA</superscript>">
 <!-- NVIDIA -->
-<!ENTITY nvidia-rev           "595">
+<!ENTITY nvidia-rev           "610">
 <!ENTITY nvidia-linux-version "6.17.x - 7.0.x">
-<!ENTITY nvidia-version       "&nvidia-rev;.71.05">
+<!ENTITY nvidia-version       "&nvidia-rev;.43.02">
 <!ENTITY nvidia-full-name     "&nvidia-version;<!-- &nvidia-beta;-->">
+<!--
 <!ENTITY nv-manifest-version  "2">
 <!ENTITY nv-sysv-bs           "2">
-<!ENTITY cuda-version         "13.2.1">
-<!ENTITY cuda-nvidia-version  "595.58.03">
+-->
+<!ENTITY cuda-version         "13.3.0">
+<!ENTITY cuda-nvidia-version  "610.43.02">
 <!-- NVIDIA r580 -->
 <!ENTITY nvidia-r580-linux-version "6.15.x - 7.0.x">
-<!ENTITY nvidia-r580-version       "580.159.03">
+<!ENTITY nvidia-r580-version       "580.159.04">
 <!ENTITY nvidia-r580-full-name     "&nvidia-r580-version;">
+<!--
 <!ENTITY nv-r580-manifest-version  "1">
 <!ENTITY nv-r580-sysv-bs           "1">
+-->
 <!ENTITY cuda-r580-version         "13.0.3">
 <!ENTITY cuda-r580-nvidia-version  "580.126.20">
 <!-- X11 -->
@@ -283,7 +287,7 @@
 <!ENTITY libxkbcommon-version         "d1442aaa6b635551182e83c3b55037f4c118c962">
 <!ENTITY libxkbcommon-real            "1.13.2">
 <!ENTITY sdl3-version                 "3.4.10">
-<!ENTITY sdl2-version                 "2.32.68">
+<!ENTITY sdl2-version                 "2.32.70">
 
 <!ENTITY nasm-version                 "3.01">
 <!ENTITY svt-av1-version              "4.1.0">
@@ -295,7 +299,7 @@
 <!ENTITY x264-version                 "20250815">
 <!ENTITY x265-version                 "4.2">
 <!ENTITY ffmpeg-version               "8.1.1">
-<!ENTITY gstreamer10-version          "1.28.3">  <!-- Even minors only -->
+<!ENTITY gstreamer10-version          "1.28.4">  <!-- Even minors only -->
 <!ENTITY gst10-plugins-base-version   "&gstreamer10-version;">
 <!ENTITY gst10-plugins-good-version   "&gstreamer10-version;">
 <!ENTITY gst10-plugins-bad-version    "&gstreamer10-version;">
@@ -303,7 +307,7 @@
 <!ENTITY gst10-libav-version          "&gstreamer10-version;">
 
 <!ENTITY wine-major-version           "11">
-<!ENTITY wine-version                 "&wine-major-version;.10">
+<!ENTITY wine-version                 "&wine-major-version;.11">
 
 <!ENTITY dxvk-version                 "2.7.1">
 <!ENTITY dxvk-libdisplay-info         "275e6459c7ab1ddd4b125f28d0440716e4888078">

--- a/shareddeps/api/libglvnd.xml
+++ b/shareddeps/api/libglvnd.xml
@@ -52,6 +52,16 @@
       </listitem>
     </itemizedlist>
 
+    <bridgehead renderas="sect3">Ytterligere nedlastinger</bridgehead>
+    <itemizedlist spacing="compact">
+      <listitem>
+        <para>
+          Påkrevd oppdatering:
+          <ulink url="&dl-root;/libglvnd/libglvnd-v&libglvnd-version;-ext_device-1.patch"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
     <bridgehead renderas="sect3">libglvnd Avhengigheter</bridgehead>
 
     <para role="recommended">
@@ -72,6 +82,20 @@
 
   <sect2 role="installation">
     <title>Installasjon av libglvnd</title>
+
+    <para>
+      Noen ikke-Mesa drivere vil eksponere en eller to EGL enhetsutvidelser fra
+      <literal>EGL_EXT_device_base</literal>,
+      <literal>EGL_EXT_device_enumeration</literal>, og
+      <literal>EGL_EXT_device_query</literal>. Noen pakker krever at alle tre 
+      utvidelsene er til stede, selv om det historisk er
+      <literal>base</literal> som beviser at <literal>enumeration</literal> og
+      <literal>query</literal> er mulig, siden de to sistnevnte er nyere 
+      utvidelser som skiller førstnevnte i to. Installer en oppdatering for å 
+      få libglvnd til å annonsere alle tre hvis en er tilstede:
+    </para>
+
+<screen><userinput remap="pre">patch -Np1 -i ../libglvnd-v&libglvnd-version;-ext_device-1.patch</userinput></screen>
 
     <para>
       Installer libglvnd ved å kjøre følgende kommandoer:

--- a/xent.ent
+++ b/xent.ent
@@ -404,29 +404,5 @@ ninja</userinput></screen>
         FPS kan falle til 60 FPS.
       </para>
     </listitem>
-    <listitem>
-      <para>
-        EGL_EXT Enhetsforespørsel og Enumeration: libglvnd setter opp viktige 
-        utvidelser som er en del av EGL spesifikasjonen og leveres via 
-        deklarasjonsfiler. Disse deklarasjonsfilene tilbyr også 
-        funksjonsdeklarasjoner, slik at adressene deres kan hentes. NVIDIAs 
-        biblioteker tilbyr ikke to utvidelser: <literal>EGL_EXT_device_query</literal> og
-        <literal>EGL_EXT_device_enumeration</literal>. Driveren gir imidlertid 
-        funksjonsdefinisjoner for å spørre enheter via EGL. Dette betyr at når 
-        en pakke eksplisitt sjekker etter utvidelsene, hvis <xref
-        linkend='mesa'/> ikke er installert, vil pakken håndtere tilfellet for 
-        manglende utvidelser, uansett om funksjonene som håndterer 
-        enhetsspørringer faktisk finnes eller ikke.
-      </para>
-      <para>
-        De fleste pakker gjør ikke dette. Men hvis du støter på en slik 
-        situasjon, må du sørge for at pakken ikke sjekker etter disse 
-        utvidelsene for å forhindre potensielle feil. Niri, som bruker smithay, 
-        lider av dette. Dette blir forsøkt løst oppstrøms med smithay. Ideelt 
-        sett bør NVIDIA eksportere disse utvidelsene. Den gjør ikke det på noen 
-        måte, den tilbyr bare funksjonene som gjør enhetsspørring 
-        mulig.
-      </para>
-    </listitem>
   </itemizedlist>
 </sect3>">


### PR DESCRIPTION
NSS:               3.124      -> 3.125.
Cbindgen:          0.29.3     -> 0.29.4.
Wayland-Protocols: 1.48       -> 1.49.
OpenCL-SDK: 2025.07.22 -> 2026.05.29.
NVIDIA:            595.71.05  -> 610.43.02.
CUDA:              13.2.1     -> 13.3.0.
NVIDIA-r580:       580.159.03 -> 580.159.04.
sdl2-compat:       2.32.68    -> 2.32.70.
GStreamer-Suite:   1.28.3     -> 1.28.4 (sikkerhet). Se
https://wiki.linuxfromscratch.org/blfs/ticket/23444.
Wine:              11.10      -> 11.11.
libglvnd:          Legg til en oppdatering for å annonsere alle EGL enhetsutvidelser.