### PR TITLE
Oppdater flere pakker (sikkerhet).

### DIFF
--- a/core/api/glu.xml
+++ b/core/api/glu.xml
@@ -56,7 +56,7 @@ cd    build &amp;&amp;
 
 meson setup --prefix=$XORG_PREFIX                       \
             --buildtype=release                         \
-            -D default_library=shared                   \
+            --default_library=shared                    \
             $(pkgconf opengl || echo -D gl_provider=gl) \
             .. &amp;&amp;
 ninja</userinput></screen>
@@ -73,7 +73,7 @@ ninja</userinput></screen>
     <title>Parameterforklaringer</title>
 
     <para>
-      <parameter>-D default_library=shared</parameter>: Denne parameteren 
+      <parameter>--default_library=shared</parameter>: Denne parameteren 
       sikrer at bare det delte biblioteket installeres.
     </para>
 

--- a/core/tooling/llvm.xml
+++ b/core/tooling/llvm.xml
@@ -68,6 +68,16 @@
       </listitem>
     </itemizedlist>
 
+    <bridgehead renderas="sect3">Ytterligere nedlastinger</bridgehead>
+    <itemizedlist spacing='compact'>
+      <listitem>
+        <para>
+          Påkrevd oppdatering:
+          <ulink url="&dl-root;/llvm-project/llvm-project-&llvm-version;-upstream_fix-1.patch"/>
+        </para>
+      </listitem>
+    </itemizedlist>
+
     <bridgehead renderas="sect3">LLVM Avhengigheter</bridgehead>
 
     <para role="required">
@@ -78,6 +88,12 @@
 
   <sect2 role="installation">
     <title>Installasjon av LLVM</title>
+
+    <para>
+      Installer en oppdatering for å fikse feil kodegenerering:
+    </para>
+
+<screen><userinput remap="pre">patch -Np1 -i ../llvm-project-&llvm-version;-upstream_fix-1.patch</userinput></screen>
 
     <para>
      Det er mange Python skript i denne pakken som bruker
@@ -96,8 +112,18 @@
     <screen><userinput>sed 's/utility/tool/' -i llvm/utils/FileCheck/CMakeLists.txt</userinput></screen>
 
     <para>
-      Installer LLVM ved å kjøre følgende 
-      kommandoer:
+      Opprett to konfigurasjonsfiler for å gjøre <xref linkend='gSSP'/> aktivert 
+      som standard, slik at når LLVM bygges, vil SSP være aktivert og konsistent 
+      med GCC, som &root; bruker:
+    </para>
+
+<screen role='root'><userinput>mkdir -pv /etc/clang &amp;&amp;
+for i in clang clang++; do
+  echo -fstack-protector-strong &gt; /etc/clang/$i.cfg
+done</userinput></screen>
+
+    <para>
+      Installer LLVM ved å kjøre følgende kommandoer:
     </para>
 
 <screen><userinput>mkdir build &amp;&amp;
@@ -275,27 +301,6 @@ ldconfig</userinput></screen>
       som delte biblioteker i stedet for statiske.
     </para>
 
-  </sect2>
-
-  <sect2 role="configuration">
-    <title>Konfigurere LLVM</title>
-
-    <sect3 id="llvm-config-info">
-      <title>Konfigurasjonsinformasjon</title>
-
-      <para>
-        Hvis du har bygget Clang, som &root; brukeren oppretter to 
-        konfigurasjonsfiler for å lage <xref linkend='gSSP'/> aktivert som 
-        standard for <command>clang</command> og <command>clang++</command>, så
-        standardkonfigurasjonen til SSP funksjonen deres vil være konsistent
-        med GCC:
-      </para>
-
-<screen role='root'><userinput>mkdir -pv /etc/clang &amp;&amp;
-for i in clang clang++; do
-  echo -fstack-protector-strong &gt; /etc/clang/$i.cfg
-done</userinput></screen>
-    </sect3>
   </sect2>
 
   <sect2 role="content">

--- a/core/tooling/rustc.xml
+++ b/core/tooling/rustc.xml
@@ -104,16 +104,6 @@
       </listitem>
     </itemizedlist>
 
-    <bridgehead renderas="sect3">Ytterligere Nedlastinger</bridgehead>
-    <itemizedlist spacing="compact">
-      <listitem>
-        <para>
-          Påkrevd crate:
-          <ulink url="https://github.com/rust-openssl/rust-openssl/archive/&rustc-openssl;/rust-openssl-&rustc-openssl;.tar.gz"/>
-        </para>
-      </listitem>
-    </itemizedlist>
-
     <bridgehead renderas="sect3">Rustc Avhengigheter</bridgehead>
 
     <para role="required">
@@ -263,24 +253,6 @@ fi</userinput></screen>
         om noen få kontroller består/feiler. Dette ble gjort for å unngå forvirring.
       </para>
     </note>
-
-    <para>
-      Få Rustc til å bruke en oppdatert versjon av OpenSSL crate for både 
-      OpenSSL-4 støtte og for å fikse flere sikkerhetsproblemer:
-    </para>
-
-<screen remap="pre"><userinput>tar -xf ../rust-openssl-&rustc-openssl;.tar.gz &amp;&amp;
-
-cat &gt;&gt; src/tools/cargo/Cargo.toml &lt;&lt; EOF &amp;&amp;
-<literal>[patch.crates-io]
-openssl = { path = "../../../rust-openssl-&rustc-openssl;/openssl" }
-openssl-sys = { path = "../../../rust-openssl-&rustc-openssl;/openssl-sys" }</literal>
-EOF
-
-sed -ri src/tools/cargo/Cargo.lock \
-    -e '/name = "openssl-sys"/,/^$/{/source|checksum/d;s/0.9.112/&rustc-openssl-sys-nice;/}' \
-    -e '/name = "openssl"/,/^$/{/source|checksum/d;s/0.10.76/&rustc-openssl-nice;/}'     \
-    -e '/name = "openssl-macros"/,/^$/{/source|checksum/d}'</userinput></screen>
 
 <!--
     <para>

--- a/download/llvm-project/llvm-project-22.1.8-upstream_fix-1.patch
+++ b/download/llvm-project/llvm-project-22.1.8-upstream_fix-1.patch
@@ -1,0 +1,3987 @@
+Submitted By:            Xi Ruoyao <xry111@xry111.site>
+Date:                    2026-07-18
+Initial Package Version: 22.1.8
+Upstream Status:         Applied for master but not 22.1.x
+Origin:                  Upstream PR 208683, the Rust maintainers rebased
+                         it and adapted its test suite change for 22.1.x:
+                         https://github.com/rust-lang/llvm-project/commit/abcef279cd33.patch
+Description:             Fix a bug causing wrong code on some conditions
+                         (most notably with Rust 1.97).
+
+From abcef279cd33492fe8301c8873fc535fa4dbf0d5 Mon Sep 17 00:00:00 2001
+From: Nikita Popov <npopov@redhat.com>
+Date: Fri, 10 Jul 2026 16:08:02 +0200
+Subject: [PATCH] [SDAG] Freeze condition in select of load fold (#208683)
+
+When converting `select cond, (load p1), (load p2)` to `load (select
+cond, p1, p2)`, if `cond` is poison, originally this would result in a
+`poison` result, while after the transform it would result in a load of
+poison, which is immediate UB. Fix this by freezing the condition.
+
+Fixes https://github.com/llvm/llvm-project/issues/208611.
+
+(cherry picked from commit f2dfbf06f7db1a3cace4beb9f65d5a7f6a8b6235)
+---
+ llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp |  16 +-
+ llvm/test/CodeGen/AArch64/icmp.ll             |  26 +-
+ llvm/test/CodeGen/ARM/fp16-promote.ll         |   2 +-
+ llvm/test/CodeGen/Mips/cconv/vector.ll        |  10 +-
+ llvm/test/CodeGen/Mips/cmov.ll                |   2 +-
+ llvm/test/CodeGen/NVPTX/i1-select.ll          |  14 +-
+ .../CodeGen/X86/fp-strict-scalar-cmp-fp16.ll  | 112 +-
+ llvm/test/CodeGen/X86/fp-strict-scalar-cmp.ll | 968 +++++++++++++-----
+ .../test/CodeGen/X86/fp128-libcalls-strict.ll |   2 +
+ .../CodeGen/X86/fp80-strict-scalar-cmp.ll     | 148 ++-
+ llvm/test/CodeGen/X86/isel-select-cmov.ll     |  16 +-
+ llvm/test/CodeGen/X86/select-constant-xor.ll  |  12 +-
+ llvm/test/CodeGen/X86/select-mmx.ll           |   4 +-
+ .../test/CodeGen/X86/select-of-load-poison.ll |  20 +
+ 14 files changed, 994 insertions(+), 358 deletions(-)
+ create mode 100644 llvm/test/CodeGen/X86/select-of-load-poison.ll
+
+diff --git a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+index ee9238753735a..dec92eff5bc19 100644
+--- a/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
++++ b/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp
+@@ -29318,10 +29318,12 @@ bool DAGCombiner::SimplifySelectOps(SDNode *TheSelect, SDValue LHS,
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
+-      Addr = DAG.getSelect(SDLoc(TheSelect),
+-                           LLD->getBasePtr().getValueType(),
+-                           TheSelect->getOperand(0), LLD->getBasePtr(),
+-                           RLD->getBasePtr());
++      // If the condition is poison, originally this would result in a poison
++      // result. After the transform, this would result in a load of poison,
++      // which is UB. Freeze the condition to prevent this.
++      Addr = DAG.getSelect(SDLoc(TheSelect), LLD->getBasePtr().getValueType(),
++                           DAG.getFreeze(TheSelect->getOperand(0)),
++                           LLD->getBasePtr(), RLD->getBasePtr());
+     } else {  // Otherwise SELECT_CC
+       // We cannot do this optimization if any pair of {RLD, LLD} is a
+       // predecessor to {RLD, LLD, CondLHS, CondRHS}. As we've already compared
+@@ -29340,10 +29342,10 @@ bool DAGCombiner::SimplifySelectOps(SDNode *TheSelect, SDValue LHS,
+            SDNode::hasPredecessorHelper(RLD, Visited, Worklist)))
+         return false;
+ 
++      SDValue FrozenOp0 = DAG.getFreeze(TheSelect->getOperand(0));
++      SDValue FrozenOp1 = DAG.getFreeze(TheSelect->getOperand(1));
+       Addr = DAG.getNode(ISD::SELECT_CC, SDLoc(TheSelect),
+-                         LLD->getBasePtr().getValueType(),
+-                         TheSelect->getOperand(0),
+-                         TheSelect->getOperand(1),
++                         LLD->getBasePtr().getValueType(), FrozenOp0, FrozenOp1,
+                          LLD->getBasePtr(), RLD->getBasePtr(),
+                          TheSelect->getOperand(4));
+     }
+diff --git a/llvm/test/CodeGen/AArch64/icmp.ll b/llvm/test/CodeGen/AArch64/icmp.ll
+index 7195e2b2f1255..920d5a090c303 100644
+--- a/llvm/test/CodeGen/AArch64/icmp.ll
++++ b/llvm/test/CodeGen/AArch64/icmp.ll
+@@ -1379,26 +1379,22 @@ entry:
+ define <2 x i128> @v2i128_i128(<2 x i128> %a, <2 x i128> %b, <2 x i128> %d, <2 x i128> %e) {
+ ; CHECK-SD-LABEL: v2i128_i128:
+ ; CHECK-SD:       // %bb.0: // %entry
++; CHECK-SD-NEXT:    cmp x2, x6
+ ; CHECK-SD-NEXT:    add x10, sp, #32
+ ; CHECK-SD-NEXT:    mov x11, sp
++; CHECK-SD-NEXT:    sbcs xzr, x3, x7
++; CHECK-SD-NEXT:    cset w8, lt
+ ; CHECK-SD-NEXT:    cmp x0, x4
+-; CHECK-SD-NEXT:    orr x12, x10, #0x8
+-; CHECK-SD-NEXT:    orr x13, x11, #0x8
+ ; CHECK-SD-NEXT:    sbcs xzr, x1, x5
++; CHECK-SD-NEXT:    cset w9, lt
++; CHECK-SD-NEXT:    cmp w9, #0
++; CHECK-SD-NEXT:    csel x9, x11, x10, ne
++; CHECK-SD-NEXT:    cmp w8, #0
+ ; CHECK-SD-NEXT:    add x8, sp, #48
+-; CHECK-SD-NEXT:    add x9, sp, #16
+-; CHECK-SD-NEXT:    csel x12, x13, x12, lt
+-; CHECK-SD-NEXT:    csel x10, x11, x10, lt
+-; CHECK-SD-NEXT:    cmp x2, x6
+-; CHECK-SD-NEXT:    orr x11, x8, #0x8
+-; CHECK-SD-NEXT:    orr x13, x9, #0x8
+-; CHECK-SD-NEXT:    sbcs xzr, x3, x7
+-; CHECK-SD-NEXT:    ldr x0, [x10]
+-; CHECK-SD-NEXT:    csel x8, x9, x8, lt
+-; CHECK-SD-NEXT:    csel x9, x13, x11, lt
+-; CHECK-SD-NEXT:    ldr x1, [x12]
+-; CHECK-SD-NEXT:    ldr x2, [x8]
+-; CHECK-SD-NEXT:    ldr x3, [x9]
++; CHECK-SD-NEXT:    add x10, sp, #16
++; CHECK-SD-NEXT:    ldp x0, x1, [x9]
++; CHECK-SD-NEXT:    csel x8, x10, x8, ne
++; CHECK-SD-NEXT:    ldp x2, x3, [x8]
+ ; CHECK-SD-NEXT:    ret
+ ;
+ ; CHECK-GI-LABEL: v2i128_i128:
+diff --git a/llvm/test/CodeGen/ARM/fp16-promote.ll b/llvm/test/CodeGen/ARM/fp16-promote.ll
+index 27a0bf2eb9037..5b3539def98a0 100644
+--- a/llvm/test/CodeGen/ARM/fp16-promote.ll
++++ b/llvm/test/CodeGen/ARM/fp16-promote.ll
+@@ -348,7 +348,7 @@ define half @test_tailcall_flipped(half %a, half %b) #0 {
+ ; No conversion is needed
+ define void @test_select(ptr %p, ptr %q, i1 zeroext %c) #0 {
+ ; CHECK-ALL-LABEL: test_select:
+-; CHECK-ALL:         cmp r2, #0
++; CHECK-ALL:         tst r2, #1
+ ; CHECK-ALL-NEXT:    movne r1, r0
+ ; CHECK-ALL-NEXT:    ldrh r1, [r1]
+ ; CHECK-ALL-NEXT:    strh r1, [r0]
+diff --git a/llvm/test/CodeGen/Mips/cconv/vector.ll b/llvm/test/CodeGen/Mips/cconv/vector.ll
+index c64c60ddef73d..5cd2b77615fcd 100644
+--- a/llvm/test/CodeGen/Mips/cconv/vector.ll
++++ b/llvm/test/CodeGen/Mips/cconv/vector.ll
+@@ -6038,15 +6038,15 @@ entry:
+ define <4 x float> @select(<4 x i32> %cond, <4 x float> %arg1, <4 x float> %arg2) {
+ ; MIPS32-LABEL: select:
+ ; MIPS32:       # %bb.0: # %entry
+-; MIPS32-NEXT:    andi $1, $7, 1
+-; MIPS32-NEXT:    lw $2, 16($sp)
+-; MIPS32-NEXT:    andi $2, $2, 1
++; MIPS32-NEXT:    lw $1, 16($sp)
++; MIPS32-NEXT:    andi $2, $7, 1
++; MIPS32-NEXT:    andi $1, $1, 1
+ ; MIPS32-NEXT:    addiu $3, $sp, 44
+ ; MIPS32-NEXT:    addiu $5, $sp, 28
+ ; MIPS32-NEXT:    addiu $7, $sp, 48
+ ; MIPS32-NEXT:    addiu $8, $sp, 32
+-; MIPS32-NEXT:    movn $7, $8, $2
+-; MIPS32-NEXT:    movn $3, $5, $1
++; MIPS32-NEXT:    movn $7, $8, $1
++; MIPS32-NEXT:    movn $3, $5, $2
+ ; MIPS32-NEXT:    andi $1, $6, 1
+ ; MIPS32-NEXT:    addiu $2, $sp, 40
+ ; MIPS32-NEXT:    addiu $5, $sp, 24
+diff --git a/llvm/test/CodeGen/Mips/cmov.ll b/llvm/test/CodeGen/Mips/cmov.ll
+index bb3c7c27a122d..ee60b353b86b6 100644
+--- a/llvm/test/CodeGen/Mips/cmov.ll
++++ b/llvm/test/CodeGen/Mips/cmov.ll
+@@ -65,7 +65,7 @@ entry:
+ 
+ ; 64-CMOV:      daddiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got_disp(d)
+ ; 64-CMOV:      daddiu $[[R0:[0-9]+]], ${{[0-9]+}}, %got_disp(c)
+-; 64-CMOV:      movn  $[[R1]], $[[R0]], $4
++; 64-CMOV:      movn  $[[R1]], $[[R0]], $2
+ 
+ ; 64-CMP-DAG:   daddiu $[[R1:[0-9]+]], ${{[0-9]+}}, %got_disp(d)
+ ; 64-CMP-DAG:   daddiu $[[R0:[0-9]+]], ${{[0-9]+}}, %got_disp(c)
+diff --git a/llvm/test/CodeGen/NVPTX/i1-select.ll b/llvm/test/CodeGen/NVPTX/i1-select.ll
+index c91a3df204d80..c13e494c3077a 100644
+--- a/llvm/test/CodeGen/NVPTX/i1-select.ll
++++ b/llvm/test/CodeGen/NVPTX/i1-select.ll
+@@ -70,9 +70,9 @@ define i32 @test_select_i1_trunc_2(i64 %a, i16 %b, i32 %c, i32 %true, i32 %false
+ define i32 @test_select_i1_basic(i32 %v1, i32 %v2, i32 %v3, i32 %true, i32 %false) {
+ ; CHECK-LABEL: test_select_i1_basic(
+ ; CHECK:       {
+-; CHECK-NEXT:    .reg .pred %p<4>;
++; CHECK-NEXT:    .reg .pred %p<6>;
+ ; CHECK-NEXT:    .reg .b32 %r<6>;
+-; CHECK-NEXT:    .reg .b64 %rd<6>;
++; CHECK-NEXT:    .reg .b64 %rd<4>;
+ ; CHECK-EMPTY:
+ ; CHECK-NEXT:  // %bb.0:
+ ; CHECK-NEXT:    ld.param.b32 %r1, [test_select_i1_basic_param_0];
+@@ -81,13 +81,13 @@ define i32 @test_select_i1_basic(i32 %v1, i32 %v2, i32 %v3, i32 %true, i32 %fals
+ ; CHECK-NEXT:    setp.ne.b32 %p1, %r1, 0;
+ ; CHECK-NEXT:    ld.param.b32 %r4, [test_select_i1_basic_param_2];
+ ; CHECK-NEXT:    setp.eq.b32 %p2, %r4, 0;
+-; CHECK-NEXT:    setp.eq.b32 %p3, %r3, 0;
++; CHECK-NEXT:    and.pred %p3, %p1, %p2;
++; CHECK-NEXT:    setp.eq.b32 %p4, %r3, 0;
++; CHECK-NEXT:    or.pred %p5, %p4, %p3;
+ ; CHECK-NEXT:    mov.b64 %rd1, test_select_i1_basic_param_4;
+ ; CHECK-NEXT:    mov.b64 %rd2, test_select_i1_basic_param_3;
+-; CHECK-NEXT:    selp.b64 %rd3, %rd2, %rd1, %p2;
+-; CHECK-NEXT:    selp.b64 %rd4, %rd3, %rd1, %p1;
+-; CHECK-NEXT:    selp.b64 %rd5, %rd2, %rd4, %p3;
+-; CHECK-NEXT:    ld.param.b32 %r5, [%rd5];
++; CHECK-NEXT:    selp.b64 %rd3, %rd2, %rd1, %p5;
++; CHECK-NEXT:    ld.param.b32 %r5, [%rd3];
+ ; CHECK-NEXT:    st.param.b32 [func_retval0], %r5;
+ ; CHECK-NEXT:    ret;
+   %b1 = icmp eq i32 %v1, 0
+diff --git a/llvm/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll b/llvm/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll
+index 6a6b86e8efa7c..1c06160584f92 100644
+--- a/llvm/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll
++++ b/llvm/test/CodeGen/X86/fp-strict-scalar-cmp-fp16.ll
+@@ -49,10 +49,13 @@ define i32 @test_f16_oeq_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    sete %cl
++; X86-FP16-NEXT:    andb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -112,9 +115,11 @@ define i32 @test_f16_ogt_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -173,9 +178,11 @@ define i32 @test_f16_oge_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -236,9 +243,11 @@ define i32 @test_f16_olt_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -299,9 +308,11 @@ define i32 @test_f16_ole_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -360,6 +371,8 @@ define i32 @test_f16_one_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setne %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+@@ -421,9 +434,11 @@ define i32 @test_f16_ord_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovnpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -482,9 +497,11 @@ define i32 @test_f16_ueq_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    sete %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -545,9 +562,11 @@ define i32 @test_f16_ugt_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -608,9 +627,11 @@ define i32 @test_f16_uge_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -669,9 +690,11 @@ define i32 @test_f16_ult_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -730,9 +753,11 @@ define i32 @test_f16_ule_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -793,10 +818,13 @@ define i32 @test_f16_une_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    setne %cl
++; X86-FP16-NEXT:    orb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -856,9 +884,11 @@ define i32 @test_f16_uno_q(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vucomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -919,10 +949,13 @@ define i32 @test_f16_oeq_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    sete %cl
++; X86-FP16-NEXT:    andb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -982,9 +1015,11 @@ define i32 @test_f16_ogt_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1043,9 +1078,11 @@ define i32 @test_f16_oge_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1106,9 +1143,11 @@ define i32 @test_f16_olt_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    seta %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmoval %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1169,9 +1208,11 @@ define i32 @test_f16_ole_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setae %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovael %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1230,6 +1271,8 @@ define i32 @test_f16_one_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setne %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+@@ -1291,9 +1334,11 @@ define i32 @test_f16_ord_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setnp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovnpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1352,9 +1397,11 @@ define i32 @test_f16_ueq_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    sete %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1415,9 +1462,11 @@ define i32 @test_f16_ugt_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1478,9 +1527,11 @@ define i32 @test_f16_uge_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1539,9 +1590,11 @@ define i32 @test_f16_ult_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setb %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1600,9 +1653,11 @@ define i32 @test_f16_ule_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setbe %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovbel %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1663,10 +1718,13 @@ define i32 @test_f16_une_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    setne %cl
++; X86-FP16-NEXT:    orb %al, %cl
++; X86-FP16-NEXT:    testb $1, %cl
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-FP16-NEXT:    cmovnel %eax, %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+@@ -1726,9 +1784,11 @@ define i32 @test_f16_uno_s(i32 %a, i32 %b, half %f1, half %f2) #0 {
+ ; X86-FP16:       # %bb.0:
+ ; X86-FP16-NEXT:    vmovsh {{.*#+}} xmm0 = mem[0],zero,zero,zero,zero,zero,zero,zero
+ ; X86-FP16-NEXT:    vcomish {{[0-9]+}}(%esp), %xmm0
++; X86-FP16-NEXT:    setp %al
++; X86-FP16-NEXT:    testb $1, %al
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-FP16-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X86-FP16-NEXT:    cmovpl %eax, %ecx
++; X86-FP16-NEXT:    cmovnel %eax, %ecx
+ ; X86-FP16-NEXT:    movl (%ecx), %eax
+ ; X86-FP16-NEXT:    retl
+ ;
+diff --git a/llvm/test/CodeGen/X86/fp-strict-scalar-cmp.ll b/llvm/test/CodeGen/X86/fp-strict-scalar-cmp.ll
+index e3e2b6225a7ba..b9823fd5646cc 100644
+--- a/llvm/test/CodeGen/X86/fp-strict-scalar-cmp.ll
++++ b/llvm/test/CodeGen/X86/fp-strict-scalar-cmp.ll
+@@ -13,10 +13,13 @@ define i32 @test_f32_oeq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -32,10 +35,13 @@ define i32 @test_f32_oeq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -56,13 +62,17 @@ define i32 @test_f32_oeq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB0_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB0_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB0_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB0_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB0_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -73,10 +83,13 @@ define i32 @test_f32_oeq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -91,9 +104,11 @@ define i32 @test_f32_ogt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -108,9 +123,11 @@ define i32 @test_f32_ogt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -130,7 +147,9 @@ define i32 @test_f32_ogt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB1_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB1_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -147,9 +166,11 @@ define i32 @test_f32_ogt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -164,9 +185,11 @@ define i32 @test_f32_oge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -181,9 +204,11 @@ define i32 @test_f32_oge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -203,7 +228,9 @@ define i32 @test_f32_oge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB2_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB2_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -220,9 +247,11 @@ define i32 @test_f32_oge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -237,9 +266,11 @@ define i32 @test_f32_olt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -254,9 +285,11 @@ define i32 @test_f32_olt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -276,7 +309,9 @@ define i32 @test_f32_olt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB3_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB3_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -293,9 +328,11 @@ define i32 @test_f32_olt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -310,9 +347,11 @@ define i32 @test_f32_ole_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -327,9 +366,11 @@ define i32 @test_f32_ole_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -349,7 +390,9 @@ define i32 @test_f32_ole_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB4_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB4_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -366,9 +409,11 @@ define i32 @test_f32_ole_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -383,6 +428,8 @@ define i32 @test_f32_one_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -400,6 +447,8 @@ define i32 @test_f32_one_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -422,6 +471,8 @@ define i32 @test_f32_one_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB5_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -439,6 +490,8 @@ define i32 @test_f32_one_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -456,9 +509,11 @@ define i32 @test_f32_ord_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -473,9 +528,11 @@ define i32 @test_f32_ord_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -495,7 +552,9 @@ define i32 @test_f32_ord_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB6_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB6_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -512,9 +571,11 @@ define i32 @test_f32_ord_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -529,9 +590,11 @@ define i32 @test_f32_ueq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -546,9 +609,11 @@ define i32 @test_f32_ueq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -568,7 +633,9 @@ define i32 @test_f32_ueq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB7_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB7_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -585,9 +652,11 @@ define i32 @test_f32_ueq_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -602,9 +671,11 @@ define i32 @test_f32_ugt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -619,9 +690,11 @@ define i32 @test_f32_ugt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -641,7 +714,9 @@ define i32 @test_f32_ugt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB8_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB8_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -658,9 +733,11 @@ define i32 @test_f32_ugt_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -675,9 +752,11 @@ define i32 @test_f32_uge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -692,9 +771,11 @@ define i32 @test_f32_uge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -714,7 +795,9 @@ define i32 @test_f32_uge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB9_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB9_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -731,9 +814,11 @@ define i32 @test_f32_uge_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -748,9 +833,11 @@ define i32 @test_f32_ult_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -765,9 +852,11 @@ define i32 @test_f32_ult_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -787,7 +876,9 @@ define i32 @test_f32_ult_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB10_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB10_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -804,9 +895,11 @@ define i32 @test_f32_ult_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -821,9 +914,11 @@ define i32 @test_f32_ule_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -838,9 +933,11 @@ define i32 @test_f32_ule_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -860,7 +957,9 @@ define i32 @test_f32_ule_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB11_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB11_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -877,9 +976,11 @@ define i32 @test_f32_ule_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -894,10 +995,13 @@ define i32 @test_f32_une_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -913,10 +1017,13 @@ define i32 @test_f32_une_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -937,13 +1044,17 @@ define i32 @test_f32_une_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB12_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB12_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB12_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB12_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB12_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -954,10 +1065,13 @@ define i32 @test_f32_une_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -972,9 +1086,11 @@ define i32 @test_f32_uno_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    ucomiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -989,9 +1105,11 @@ define i32 @test_f32_uno_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vucomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1011,7 +1129,9 @@ define i32 @test_f32_uno_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB13_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB13_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1028,9 +1148,11 @@ define i32 @test_f32_uno_q(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f32(
+@@ -1045,10 +1167,13 @@ define i32 @test_f64_oeq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1064,10 +1189,13 @@ define i32 @test_f64_oeq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1088,13 +1216,17 @@ define i32 @test_f64_oeq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB14_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB14_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB14_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB14_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB14_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -1105,10 +1237,13 @@ define i32 @test_f64_oeq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1123,9 +1258,11 @@ define i32 @test_f64_ogt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1140,9 +1277,11 @@ define i32 @test_f64_ogt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1162,7 +1301,9 @@ define i32 @test_f64_ogt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB15_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB15_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1179,9 +1320,11 @@ define i32 @test_f64_ogt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1196,9 +1339,11 @@ define i32 @test_f64_oge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1213,9 +1358,11 @@ define i32 @test_f64_oge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1235,7 +1382,9 @@ define i32 @test_f64_oge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB16_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB16_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1252,9 +1401,11 @@ define i32 @test_f64_oge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1269,9 +1420,11 @@ define i32 @test_f64_olt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1286,9 +1439,11 @@ define i32 @test_f64_olt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1308,7 +1463,9 @@ define i32 @test_f64_olt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB17_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB17_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1325,9 +1482,11 @@ define i32 @test_f64_olt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1342,9 +1501,11 @@ define i32 @test_f64_ole_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1359,9 +1520,11 @@ define i32 @test_f64_ole_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1381,7 +1544,9 @@ define i32 @test_f64_ole_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB18_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB18_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1398,9 +1563,11 @@ define i32 @test_f64_ole_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1415,6 +1582,8 @@ define i32 @test_f64_one_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -1432,6 +1601,8 @@ define i32 @test_f64_one_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -1454,6 +1625,8 @@ define i32 @test_f64_one_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB19_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -1471,6 +1644,8 @@ define i32 @test_f64_one_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -1488,9 +1663,11 @@ define i32 @test_f64_ord_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1505,9 +1682,11 @@ define i32 @test_f64_ord_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1527,7 +1706,9 @@ define i32 @test_f64_ord_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB20_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB20_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1544,9 +1725,11 @@ define i32 @test_f64_ord_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1561,9 +1744,11 @@ define i32 @test_f64_ueq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1578,9 +1763,11 @@ define i32 @test_f64_ueq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1600,7 +1787,9 @@ define i32 @test_f64_ueq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB21_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB21_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1617,9 +1806,11 @@ define i32 @test_f64_ueq_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1634,9 +1825,11 @@ define i32 @test_f64_ugt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1651,9 +1844,11 @@ define i32 @test_f64_ugt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1673,7 +1868,9 @@ define i32 @test_f64_ugt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB22_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB22_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1690,9 +1887,11 @@ define i32 @test_f64_ugt_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1707,9 +1906,11 @@ define i32 @test_f64_uge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1724,9 +1925,11 @@ define i32 @test_f64_uge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1746,7 +1949,9 @@ define i32 @test_f64_uge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB23_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB23_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1763,9 +1968,11 @@ define i32 @test_f64_uge_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1780,9 +1987,11 @@ define i32 @test_f64_ult_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1797,9 +2006,11 @@ define i32 @test_f64_ult_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1819,7 +2030,9 @@ define i32 @test_f64_ult_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB24_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB24_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1836,9 +2049,11 @@ define i32 @test_f64_ult_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1853,9 +2068,11 @@ define i32 @test_f64_ule_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1870,9 +2087,11 @@ define i32 @test_f64_ule_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1892,7 +2111,9 @@ define i32 @test_f64_ule_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB25_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB25_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -1909,9 +2130,11 @@ define i32 @test_f64_ule_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -1926,10 +2149,13 @@ define i32 @test_f64_une_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -1945,10 +2171,13 @@ define i32 @test_f64_une_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -1969,13 +2198,17 @@ define i32 @test_f64_une_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB26_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB26_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB26_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB26_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB26_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -1986,10 +2219,13 @@ define i32 @test_f64_une_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -2004,9 +2240,11 @@ define i32 @test_f64_uno_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    ucomisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2021,9 +2259,11 @@ define i32 @test_f64_uno_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vucomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2043,7 +2283,9 @@ define i32 @test_f64_uno_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB27_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB27_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2060,9 +2302,11 @@ define i32 @test_f64_uno_q(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fucompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmp.f64(
+@@ -2077,10 +2321,13 @@ define i32 @test_f32_oeq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2096,10 +2343,13 @@ define i32 @test_f32_oeq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2120,13 +2370,17 @@ define i32 @test_f32_oeq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB28_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB28_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB28_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB28_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB28_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -2137,10 +2391,13 @@ define i32 @test_f32_oeq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2155,9 +2412,11 @@ define i32 @test_f32_ogt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2172,9 +2431,11 @@ define i32 @test_f32_ogt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2194,7 +2455,9 @@ define i32 @test_f32_ogt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB29_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB29_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2211,9 +2474,11 @@ define i32 @test_f32_ogt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2228,9 +2493,11 @@ define i32 @test_f32_oge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2245,9 +2512,11 @@ define i32 @test_f32_oge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2267,7 +2536,9 @@ define i32 @test_f32_oge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB30_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB30_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2284,9 +2555,11 @@ define i32 @test_f32_oge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2301,9 +2574,11 @@ define i32 @test_f32_olt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2318,9 +2593,11 @@ define i32 @test_f32_olt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2340,7 +2617,9 @@ define i32 @test_f32_olt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB31_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB31_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2357,9 +2636,11 @@ define i32 @test_f32_olt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2374,9 +2655,11 @@ define i32 @test_f32_ole_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2391,9 +2674,11 @@ define i32 @test_f32_ole_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2413,7 +2698,9 @@ define i32 @test_f32_ole_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB32_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB32_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2430,9 +2717,11 @@ define i32 @test_f32_ole_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2447,6 +2736,8 @@ define i32 @test_f32_one_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -2464,6 +2755,8 @@ define i32 @test_f32_one_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -2486,6 +2779,8 @@ define i32 @test_f32_one_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB33_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -2503,6 +2798,8 @@ define i32 @test_f32_one_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -2520,9 +2817,11 @@ define i32 @test_f32_ord_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2537,9 +2836,11 @@ define i32 @test_f32_ord_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2559,7 +2860,9 @@ define i32 @test_f32_ord_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB34_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB34_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2576,9 +2879,11 @@ define i32 @test_f32_ord_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2593,9 +2898,11 @@ define i32 @test_f32_ueq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2610,9 +2917,11 @@ define i32 @test_f32_ueq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2632,7 +2941,9 @@ define i32 @test_f32_ueq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB35_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB35_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2649,9 +2960,11 @@ define i32 @test_f32_ueq_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2666,9 +2979,11 @@ define i32 @test_f32_ugt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2683,9 +2998,11 @@ define i32 @test_f32_ugt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2705,7 +3022,9 @@ define i32 @test_f32_ugt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB36_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB36_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2722,9 +3041,11 @@ define i32 @test_f32_ugt_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2739,9 +3060,11 @@ define i32 @test_f32_uge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2756,9 +3079,11 @@ define i32 @test_f32_uge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2778,7 +3103,9 @@ define i32 @test_f32_uge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB37_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB37_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2795,9 +3122,11 @@ define i32 @test_f32_uge_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2812,9 +3141,11 @@ define i32 @test_f32_ult_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2829,9 +3160,11 @@ define i32 @test_f32_ult_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2851,7 +3184,9 @@ define i32 @test_f32_ult_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB38_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB38_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2868,9 +3203,11 @@ define i32 @test_f32_ult_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2885,9 +3222,11 @@ define i32 @test_f32_ule_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2902,9 +3241,11 @@ define i32 @test_f32_ule_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -2924,7 +3265,9 @@ define i32 @test_f32_ule_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB39_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB39_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -2941,9 +3284,11 @@ define i32 @test_f32_ule_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -2958,10 +3303,13 @@ define i32 @test_f32_une_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -2977,10 +3325,13 @@ define i32 @test_f32_une_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3001,13 +3352,17 @@ define i32 @test_f32_une_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB40_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB40_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB40_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB40_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB40_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -3018,10 +3373,13 @@ define i32 @test_f32_une_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -3036,9 +3394,11 @@ define i32 @test_f32_uno_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; SSE-32-NEXT:    comiss {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3053,9 +3413,11 @@ define i32 @test_f32_uno_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
+ ; AVX-32-NEXT:    vcomiss {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3075,7 +3437,9 @@ define i32 @test_f32_uno_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB41_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB41_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3092,9 +3456,11 @@ define i32 @test_f32_uno_s(i32 %a, i32 %b, float %f1, float %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f32(
+@@ -3109,10 +3475,13 @@ define i32 @test_f64_oeq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    sete %cl
++; SSE-32-NEXT:    andb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3128,10 +3497,13 @@ define i32 @test_f64_oeq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    sete %cl
++; AVX-32-NEXT:    andb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3152,13 +3524,17 @@ define i32 @test_f64_oeq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB42_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB42_3
++; X87-NEXT:    setnp %al
++; X87-NEXT:    sete %cl
++; X87-NEXT:    andb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB42_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB42_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB42_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -3169,10 +3545,13 @@ define i32 @test_f64_oeq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    sete %cl
++; X87-CMOV-NEXT:    andb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3187,9 +3566,11 @@ define i32 @test_f64_ogt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3204,9 +3585,11 @@ define i32 @test_f64_ogt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3226,7 +3609,9 @@ define i32 @test_f64_ogt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB43_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB43_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3243,9 +3628,11 @@ define i32 @test_f64_ogt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3260,9 +3647,11 @@ define i32 @test_f64_oge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3277,9 +3666,11 @@ define i32 @test_f64_oge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3299,7 +3690,9 @@ define i32 @test_f64_oge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB44_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB44_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3316,9 +3709,11 @@ define i32 @test_f64_oge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3333,9 +3728,11 @@ define i32 @test_f64_olt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    seta %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmoval %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3350,9 +3747,11 @@ define i32 @test_f64_olt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    seta %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmoval %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3372,7 +3771,9 @@ define i32 @test_f64_olt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    ja .LBB45_1
++; X87-NEXT:    seta %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB45_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3389,9 +3790,11 @@ define i32 @test_f64_olt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    seta %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmoval %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3406,9 +3809,11 @@ define i32 @test_f64_ole_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setae %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovael %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3423,9 +3828,11 @@ define i32 @test_f64_ole_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setae %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovael %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3445,7 +3852,9 @@ define i32 @test_f64_ole_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jae .LBB46_1
++; X87-NEXT:    setae %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB46_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3462,9 +3871,11 @@ define i32 @test_f64_ole_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setae %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovael %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3479,6 +3890,8 @@ define i32 @test_f64_one_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setne %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+@@ -3496,6 +3909,8 @@ define i32 @test_f64_one_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setne %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+@@ -3518,6 +3933,8 @@ define i32 @test_f64_one_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
++; X87-NEXT:    setne %al
++; X87-NEXT:    testb $1, %al
+ ; X87-NEXT:    jne .LBB47_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -3535,6 +3952,8 @@ define i32 @test_f64_one_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setne %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -3552,9 +3971,11 @@ define i32 @test_f64_ord_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setnp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovnpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3569,9 +3990,11 @@ define i32 @test_f64_ord_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setnp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovnpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3591,7 +4014,9 @@ define i32 @test_f64_ord_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jnp .LBB48_1
++; X87-NEXT:    setnp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB48_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3608,9 +4033,11 @@ define i32 @test_f64_ord_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setnp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovnpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3625,9 +4052,11 @@ define i32 @test_f64_ueq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    sete %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3642,9 +4071,11 @@ define i32 @test_f64_ueq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    sete %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3664,7 +4095,9 @@ define i32 @test_f64_ueq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    je .LBB49_1
++; X87-NEXT:    sete %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB49_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3681,9 +4114,11 @@ define i32 @test_f64_ueq_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    sete %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3698,9 +4133,11 @@ define i32 @test_f64_ugt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3715,9 +4152,11 @@ define i32 @test_f64_ugt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3737,7 +4176,9 @@ define i32 @test_f64_ugt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB50_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB50_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3754,9 +4195,11 @@ define i32 @test_f64_ugt_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3771,9 +4214,11 @@ define i32 @test_f64_uge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3788,9 +4233,11 @@ define i32 @test_f64_uge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3810,7 +4257,9 @@ define i32 @test_f64_uge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB51_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB51_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3827,9 +4276,11 @@ define i32 @test_f64_uge_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3844,9 +4295,11 @@ define i32 @test_f64_ult_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setb %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3861,9 +4314,11 @@ define i32 @test_f64_ult_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setb %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3883,7 +4338,9 @@ define i32 @test_f64_ult_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jb .LBB52_1
++; X87-NEXT:    setb %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB52_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3900,9 +4357,11 @@ define i32 @test_f64_ult_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setb %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3917,9 +4376,11 @@ define i32 @test_f64_ule_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setbe %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovbel %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -3934,9 +4395,11 @@ define i32 @test_f64_ule_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setbe %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovbel %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -3956,7 +4419,9 @@ define i32 @test_f64_ule_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jbe .LBB53_1
++; X87-NEXT:    setbe %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB53_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -3973,9 +4438,11 @@ define i32 @test_f64_ule_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setbe %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovbel %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -3990,10 +4457,13 @@ define i32 @test_f64_une_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    setne %cl
++; SSE-32-NEXT:    orb %al, %cl
++; SSE-32-NEXT:    testb $1, %cl
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SSE-32-NEXT:    cmovnel %eax, %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -4009,10 +4479,13 @@ define i32 @test_f64_une_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    setne %cl
++; AVX-32-NEXT:    orb %al, %cl
++; AVX-32-NEXT:    testb $1, %cl
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; AVX-32-NEXT:    cmovnel %eax, %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -4033,13 +4506,17 @@ define i32 @test_f64_une_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:    jne .LBB54_3
+-; X87-NEXT:  # %bb.1:
+-; X87-NEXT:    jp .LBB54_3
++; X87-NEXT:    setp %al
++; X87-NEXT:    setne %cl
++; X87-NEXT:    orb %al, %cl
++; X87-NEXT:    testb $1, %cl
++; X87-NEXT:    jne .LBB54_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X87-NEXT:  .LBB54_3:
++; X87-NEXT:    movl (%eax), %eax
++; X87-NEXT:    retl
++; X87-NEXT:  .LBB54_1:
++; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+ ; X87-NEXT:    retl
+ ;
+@@ -4050,10 +4527,13 @@ define i32 @test_f64_une_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    setne %cl
++; X87-CMOV-NEXT:    orb %al, %cl
++; X87-CMOV-NEXT:    testb $1, %cl
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+@@ -4068,9 +4548,11 @@ define i32 @test_f64_uno_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; SSE-32:       # %bb.0:
+ ; SSE-32-NEXT:    movsd {{.*#+}} xmm0 = mem[0],zero
+ ; SSE-32-NEXT:    comisd {{[0-9]+}}(%esp), %xmm0
++; SSE-32-NEXT:    setp %al
++; SSE-32-NEXT:    testb $1, %al
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SSE-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; SSE-32-NEXT:    cmovpl %eax, %ecx
++; SSE-32-NEXT:    cmovnel %eax, %ecx
+ ; SSE-32-NEXT:    movl (%ecx), %eax
+ ; SSE-32-NEXT:    retl
+ ;
+@@ -4085,9 +4567,11 @@ define i32 @test_f64_uno_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; AVX-32:       # %bb.0:
+ ; AVX-32-NEXT:    vmovsd {{.*#+}} xmm0 = mem[0],zero
+ ; AVX-32-NEXT:    vcomisd {{[0-9]+}}(%esp), %xmm0
++; AVX-32-NEXT:    setp %al
++; AVX-32-NEXT:    testb $1, %al
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; AVX-32-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; AVX-32-NEXT:    cmovpl %eax, %ecx
++; AVX-32-NEXT:    cmovnel %eax, %ecx
+ ; AVX-32-NEXT:    movl (%ecx), %eax
+ ; AVX-32-NEXT:    retl
+ ;
+@@ -4107,7 +4591,9 @@ define i32 @test_f64_uno_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-NEXT:    fnstsw %ax
+ ; X87-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X87-NEXT:    sahf
+-; X87-NEXT:    jp .LBB55_1
++; X87-NEXT:    setp %al
++; X87-NEXT:    testb $1, %al
++; X87-NEXT:    jne .LBB55_1
+ ; X87-NEXT:  # %bb.2:
+ ; X87-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-NEXT:    movl (%eax), %eax
+@@ -4124,9 +4610,11 @@ define i32 @test_f64_uno_s(i32 %a, i32 %b, double %f1, double %f2) #0 {
+ ; X87-CMOV-NEXT:    fcompi %st(1), %st
+ ; X87-CMOV-NEXT:    fstp %st(0)
+ ; X87-CMOV-NEXT:    wait
++; X87-CMOV-NEXT:    setp %al
++; X87-CMOV-NEXT:    testb $1, %al
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X87-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+-; X87-CMOV-NEXT:    cmovpl %eax, %ecx
++; X87-CMOV-NEXT:    cmovnel %eax, %ecx
+ ; X87-CMOV-NEXT:    movl (%ecx), %eax
+ ; X87-CMOV-NEXT:    retl
+   %cond = call i1 @llvm.experimental.constrained.fcmps.f64(
+diff --git a/llvm/test/CodeGen/X86/fp128-libcalls-strict.ll b/llvm/test/CodeGen/X86/fp128-libcalls-strict.ll
+index ad2d690fd7ed0..5dbc28230d5af 100644
+--- a/llvm/test/CodeGen/X86/fp128-libcalls-strict.ll
++++ b/llvm/test/CodeGen/X86/fp128-libcalls-strict.ll
+@@ -3898,6 +3898,7 @@ define i64 @cmp_ueq_q(i64 %a, i64 %b, fp128 %x, fp128 %y) #0 {
+ ; X86-NEXT:    calll __unordtf2
+ ; X86-NEXT:    addl $32, %esp
+ ; X86-NEXT:    orb %bl, %al
++; X86-NEXT:    testb $1, %al
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; X86-NEXT:    cmovnel %eax, %ecx
+@@ -3981,6 +3982,7 @@ define i64 @cmp_ueq_q(i64 %a, i64 %b, fp128 %x, fp128 %y) #0 {
+ ; WIN-X86-NEXT:    calll ___unordtf2
+ ; WIN-X86-NEXT:    addl $32, %esp
+ ; WIN-X86-NEXT:    orb %bl, %al
++; WIN-X86-NEXT:    testb $1, %al
+ ; WIN-X86-NEXT:    jne LBB39_1
+ ; WIN-X86-NEXT:  # %bb.2:
+ ; WIN-X86-NEXT:    leal 16(%ebp), %ecx
+diff --git a/llvm/test/CodeGen/X86/fp80-strict-scalar-cmp.ll b/llvm/test/CodeGen/X86/fp80-strict-scalar-cmp.ll
+index cb2361fbb8d37..f95738d9e546e 100644
+--- a/llvm/test/CodeGen/X86/fp80-strict-scalar-cmp.ll
++++ b/llvm/test/CodeGen/X86/fp80-strict-scalar-cmp.ll
+@@ -12,13 +12,17 @@ define i32 @test_oeq_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB0_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB0_3
++; X86-NEXT:    setnp %al
++; X86-NEXT:    sete %cl
++; X86-NEXT:    andb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB0_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB0_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB0_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -50,7 +54,9 @@ define i32 @test_ogt_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB1_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB1_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -87,7 +93,9 @@ define i32 @test_oge_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB2_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB2_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -124,7 +132,9 @@ define i32 @test_olt_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB3_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB3_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -161,7 +171,9 @@ define i32 @test_ole_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB4_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB4_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -198,6 +210,8 @@ define i32 @test_one_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
++; X86-NEXT:    setne %al
++; X86-NEXT:    testb $1, %al
+ ; X86-NEXT:    jne .LBB5_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -235,7 +249,9 @@ define i32 @test_ord_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jnp .LBB6_1
++; X86-NEXT:    setnp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB6_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -272,7 +288,9 @@ define i32 @test_ueq_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    je .LBB7_1
++; X86-NEXT:    sete %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB7_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -309,7 +327,9 @@ define i32 @test_ugt_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB8_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB8_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -346,7 +366,9 @@ define i32 @test_uge_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB9_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB9_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -383,7 +405,9 @@ define i32 @test_ult_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB10_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB10_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -420,7 +444,9 @@ define i32 @test_ule_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB11_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB11_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -457,13 +483,17 @@ define i32 @test_une_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB12_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB12_3
++; X86-NEXT:    setp %al
++; X86-NEXT:    setne %cl
++; X86-NEXT:    orb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB12_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB12_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB12_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -495,7 +525,9 @@ define i32 @test_uno_q(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jp .LBB13_1
++; X86-NEXT:    setp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB13_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -532,13 +564,17 @@ define i32 @test_oeq_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB14_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB14_3
++; X86-NEXT:    setnp %al
++; X86-NEXT:    sete %cl
++; X86-NEXT:    andb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB14_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB14_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB14_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -570,7 +606,9 @@ define i32 @test_ogt_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB15_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB15_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -607,7 +645,9 @@ define i32 @test_oge_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB16_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB16_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -644,7 +684,9 @@ define i32 @test_olt_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    ja .LBB17_1
++; X86-NEXT:    seta %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB17_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -681,7 +723,9 @@ define i32 @test_ole_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jae .LBB18_1
++; X86-NEXT:    setae %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB18_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -718,6 +762,8 @@ define i32 @test_one_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
++; X86-NEXT:    setne %al
++; X86-NEXT:    testb $1, %al
+ ; X86-NEXT:    jne .LBB19_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -755,7 +801,9 @@ define i32 @test_ord_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jnp .LBB20_1
++; X86-NEXT:    setnp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB20_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -792,7 +840,9 @@ define i32 @test_ueq_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    je .LBB21_1
++; X86-NEXT:    sete %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB21_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -829,7 +879,9 @@ define i32 @test_ugt_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB22_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB22_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -866,7 +918,9 @@ define i32 @test_uge_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB23_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB23_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -903,7 +957,9 @@ define i32 @test_ult_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jb .LBB24_1
++; X86-NEXT:    setb %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB24_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -940,7 +996,9 @@ define i32 @test_ule_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jbe .LBB25_1
++; X86-NEXT:    setbe %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB25_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -977,13 +1035,17 @@ define i32 @test_une_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:    jne .LBB26_3
+-; X86-NEXT:  # %bb.1:
+-; X86-NEXT:    jp .LBB26_3
++; X86-NEXT:    setp %al
++; X86-NEXT:    setne %cl
++; X86-NEXT:    orb %al, %cl
++; X86-NEXT:    testb $1, %cl
++; X86-NEXT:    jne .LBB26_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+-; X86-NEXT:  .LBB26_3:
++; X86-NEXT:    movl (%eax), %eax
++; X86-NEXT:    retl
++; X86-NEXT:  .LBB26_1:
++; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+ ; X86-NEXT:    retl
+ ;
+@@ -1015,7 +1077,9 @@ define i32 @test_uno_s(i32 %a, i32 %b, x86_fp80 %f1, x86_fp80 %f2) #0 {
+ ; X86-NEXT:    fnstsw %ax
+ ; X86-NEXT:    # kill: def $ah killed $ah killed $ax
+ ; X86-NEXT:    sahf
+-; X86-NEXT:    jp .LBB27_1
++; X86-NEXT:    setp %al
++; X86-NEXT:    testb $1, %al
++; X86-NEXT:    jne .LBB27_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+diff --git a/llvm/test/CodeGen/X86/isel-select-cmov.ll b/llvm/test/CodeGen/X86/isel-select-cmov.ll
+index d013ad2c7fbff..6ced7f45b6233 100644
+--- a/llvm/test/CodeGen/X86/isel-select-cmov.ll
++++ b/llvm/test/CodeGen/X86/isel-select-cmov.ll
+@@ -47,7 +47,7 @@ define zeroext i8 @select_cmov_i8(i1 zeroext %cond, i8 zeroext %a, i8 zeroext %b
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i8:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB0_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -60,7 +60,7 @@ define zeroext i8 @select_cmov_i8(i1 zeroext %cond, i8 zeroext %a, i8 zeroext %b
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i8:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -155,7 +155,7 @@ define zeroext i16 @select_cmov_i16(i1 zeroext %cond, i16 zeroext %a, i16 zeroex
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i16:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB1_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -168,7 +168,7 @@ define zeroext i16 @select_cmov_i16(i1 zeroext %cond, i16 zeroext %a, i16 zeroex
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i16:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -360,7 +360,7 @@ define i32 @select_cmov_i32(i1 zeroext %cond, i32 %a, i32 %b) {
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i32:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB3_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+@@ -373,7 +373,7 @@ define i32 @select_cmov_i32(i1 zeroext %cond, i32 %a, i32 %b) {
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i32:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+@@ -549,7 +549,7 @@ define i64 @select_cmov_i64(i1 zeroext %cond, i64 %a, i64 %b) {
+ ;
+ ; SDAG-X86-LABEL: select_cmov_i64:
+ ; SDAG-X86:       ## %bb.0:
+-; SDAG-X86-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-NEXT:    jne LBB5_1
+ ; SDAG-X86-NEXT:  ## %bb.2:
+ ; SDAG-X86-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+@@ -563,7 +563,7 @@ define i64 @select_cmov_i64(i1 zeroext %cond, i64 %a, i64 %b) {
+ ;
+ ; SDAG-X86-CMOV-LABEL: select_cmov_i64:
+ ; SDAG-X86-CMOV:       ## %bb.0:
+-; SDAG-X86-CMOV-NEXT:    cmpb $0, {{[0-9]+}}(%esp)
++; SDAG-X86-CMOV-NEXT:    testb $1, {{[0-9]+}}(%esp)
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; SDAG-X86-CMOV-NEXT:    leal {{[0-9]+}}(%esp), %ecx
+ ; SDAG-X86-CMOV-NEXT:    cmovnel %eax, %ecx
+diff --git a/llvm/test/CodeGen/X86/select-constant-xor.ll b/llvm/test/CodeGen/X86/select-constant-xor.ll
+index efc367d204cf1..5d80e04fef38c 100644
+--- a/llvm/test/CodeGen/X86/select-constant-xor.ll
++++ b/llvm/test/CodeGen/X86/select-constant-xor.ll
+@@ -172,8 +172,10 @@ define i32 @selecti8i32(i8 %a) {
+ define i32 @icmpasreq(i32 %input, i32 %a, i32 %b) {
+ ; X86-LABEL: icmpasreq:
+ ; X86:       # %bb.0:
+-; X86-NEXT:    cmpl $0, {{[0-9]+}}(%esp)
+-; X86-NEXT:    js .LBB8_1
++; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
++; X86-NEXT:    sarl $31, %eax
++; X86-NEXT:    cmpl $-1, %eax
++; X86-NEXT:    je .LBB8_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+@@ -198,8 +200,10 @@ define i32 @icmpasreq(i32 %input, i32 %a, i32 %b) {
+ define i32 @icmpasrne(i32 %input, i32 %a, i32 %b) {
+ ; X86-LABEL: icmpasrne:
+ ; X86:       # %bb.0:
+-; X86-NEXT:    cmpl $0, {{[0-9]+}}(%esp)
+-; X86-NEXT:    jns .LBB9_1
++; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
++; X86-NEXT:    sarl $31, %eax
++; X86-NEXT:    cmpl $-1, %eax
++; X86-NEXT:    jne .LBB9_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal {{[0-9]+}}(%esp), %eax
+ ; X86-NEXT:    movl (%eax), %eax
+diff --git a/llvm/test/CodeGen/X86/select-mmx.ll b/llvm/test/CodeGen/X86/select-mmx.ll
+index 8a4308a5af64b..cc6603382082c 100644
+--- a/llvm/test/CodeGen/X86/select-mmx.ll
++++ b/llvm/test/CodeGen/X86/select-mmx.ll
+@@ -85,8 +85,8 @@ define i64 @test49(i64 %arg, i64 %x, i64 %y) {
+ ; X86-NEXT:    .cfi_def_cfa_register %ebp
+ ; X86-NEXT:    andl $-8, %esp
+ ; X86-NEXT:    subl $8, %esp
+-; X86-NEXT:    movl 8(%ebp), %eax
+-; X86-NEXT:    orl 12(%ebp), %eax
++; X86-NEXT:    movl 12(%ebp), %eax
++; X86-NEXT:    orl 8(%ebp), %eax
+ ; X86-NEXT:    je .LBB1_1
+ ; X86-NEXT:  # %bb.2:
+ ; X86-NEXT:    leal 24(%ebp), %eax
+diff --git a/llvm/test/CodeGen/X86/select-of-load-poison.ll b/llvm/test/CodeGen/X86/select-of-load-poison.ll
+new file mode 100644
+index 0000000000000..1f71f812d2327
+--- /dev/null
++++ b/llvm/test/CodeGen/X86/select-of-load-poison.ll
+@@ -0,0 +1,20 @@
++; NOTE: Assertions have been autogenerated by utils/update_llc_test_checks.py UTC_ARGS: --version 6
++; RUN: llc -mtriple=x86_64-unknown-linux-gnu < %s | FileCheck %s
++
++; Make sure there is an and 1, otherwise a case where the select condition
++; was poison could result in an out of bounds read instead.
++define i32 @test(i32 %x, ptr %p) {
++; CHECK-LABEL: test:
++; CHECK:       # %bb.0:
++; CHECK-NEXT:    # kill: def $edi killed $edi def $rdi
++; CHECK-NEXT:    andl $1, %edi
++; CHECK-NEXT:    movl 4(%rsi,%rdi,4), %eax
++; CHECK-NEXT:    retq
++  %p1 = getelementptr i8, ptr %p, i64 4
++  %v1 = load i32, ptr %p1
++  %p2 = getelementptr i8, ptr %p, i64 8
++  %v2 = load i32, ptr %p2
++  %c = trunc nuw i32 %x to i1
++  %v = select i1 %c, i32 %v2, i32 %v1
++  ret i32 %v
++}

--- a/download/xorg-server/xorg-server-21.1.24-dri.patch
+++ b/download/xorg-server/xorg-server-21.1.24-dri.patch
@@ -1,0 +1,1 @@
+xorg-server-21.1.23-dri.patch

--- a/download/xwayland/xwayland-24.1.13-dri.patch
+++ b/download/xwayland/xwayland-24.1.13-dri.patch
@@ -1,0 +1,1 @@
+xwayland-24.1.12-dri.patch

--- a/introduction/welcome/changelog.xml
+++ b/introduction/welcome/changelog.xml
@@ -41,6 +41,92 @@
     -->
 
     <listitem>
+      <para>23. juli 2026</para>
+      <itemizedlist>
+        <listitem>
+          <para>[zeckma] - NSS: 3.125 -&gt; 3.126.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - p11-kit: 0.26.2 -&gt; 0.26.4 (sikkerhet).
+          Se BLFS billett
+          <ulink url="&blfs-ticket-root;23588">#23588</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - libpsl: 0.22.0 -&gt; 0.23.0.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - CMake: 4.3.4 -&gt; 4.4.0.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Rustc: 1.96.0 -&gt; 1.97.1.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Fontconfig: 2.18.1 -&gt; 2.18.2.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - libXfont2: 2.0.7 -&gt; 2.0.8 (sikkerhet).
+          Se BLFS billett
+          <ulink url="&blfs-ticket-root;23573">#23573</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Wayland: 1.25.0 -&gt; 1.26.0.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - libva: 2.24.0 -&gt; 2.24.1.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xkbutils: 1.0.6 -&gt; 1.0.7.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xlsatoms: 1.1.4 -&gt; 1.1.5.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xrdb: 1.2.2 -&gt; 1.2.3.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xrefresh: 1.1.0 -&gt; 1.1.1.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xset: 1.2.5 -&gt; 1.2.6.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xsetroot: 1.1.3 -&gt; 1.1.4.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xvinfo: 1.1.5 -&gt; 1.1.6.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xwd: 1.0.9 -&gt; 1.1.10.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - xwud: 1.0.7 -&gt; 1.0.8.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Xorg-Server: 21.1.23 -&gt; 21.1.24 (sikkerhet).
+          Se BLFS billett
+          <ulink url="&blfs-ticket-root;23577">#23577</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Xwayland: 24.1.12 -&gt; 24.1.13 (sikkerhet).
+          Se BLFS billett
+          <ulink url="&blfs-ticket-root;23576">#23576</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - Steam: 1.0.0.85 -&gt; 1.0.0.87. Fikser
+          <ulink url="&glfs-issues;/492">#492</ulink>.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - dav1d: 1.5.3 -&gt; 1.5.4.</para>
+        </listitem>
+        <listitem>
+          <para>[zeckma] - GStreamer: 1.28.4 -&gt; 1.28.5 (sikkerhet).
+          Se BLFS billett
+          <ulink url="&blfs-ticket-root;23579">#23579</ulink>.</para>
+        </listitem>
+      </itemizedlist>
+    </listitem>
+
+    <listitem>
       <para>21. juli 2026</para>
       <itemizedlist>
         <listitem>

--- a/packages.ent
+++ b/packages.ent
@@ -18,14 +18,14 @@
 <!ENTITY libtasn1-version             "4.21.0">
 <!ENTITY nspr-version                 "4.39">
 <!ENTITY nss-major                    "3">
-<!ENTITY nss-minor                    "125">
+<!ENTITY nss-minor                    "126">
 <!ENTITY nss-dir                      "&nss-major;_&nss-minor;">
 <!ENTITY nss-version                  "&nss-major;.&nss-minor;">
-<!ENTITY p11-kit-version              "0.26.2">
+<!ENTITY p11-kit-version              "0.26.4">
 <!ENTITY make-ca-version              "1.16.1">
 <!ENTITY libunistring-version         "1.4.2">
 <!ENTITY libidn2-version              "2.3.8">
-<!ENTITY libpsl-version               "0.22.0">
+<!ENTITY libpsl-version               "0.23.0">
 <!ENTITY curl-version                 "8.21.0">
 <!ENTITY wget-version                 "1.25.0">
 <!-- Security -->
@@ -47,20 +47,17 @@
 <!ENTITY desktop-file-utils-version   "0.28">
 <!ENTITY polkit-version               "127">
 <!-- Tooling -->
-<!ENTITY cmake-major-version          "4.3">
-<!ENTITY cmake-point-version          "4">
+<!ENTITY cmake-major-version          "4.4">
+<!ENTITY cmake-point-version          "0">
 <!ENTITY cmake-version                "&cmake-major-version;.&cmake-point-version;">
 <!ENTITY llvm-maj-version             "22">
 <!ENTITY llvm-min-version             "1">
 <!ENTITY llvm-point-version           "8">
 <!ENTITY llvm-version                 "&llvm-maj-version;.&llvm-min-version;.&llvm-point-version;">
-<!ENTITY rustc-version                "1.96.0">
+<!ENTITY rustc-version                "1.97.1">
 <!-- rustc-change-id can be found in src/bootstrap/src/utils/change_tracker.rs
      at the very bottom: change_id. -->
-<!ENTITY rustc-change-id              "154508">
-<!ENTITY rustc-openssl                "a6debf535674c9a073f455158743e6ba094cf1b4">
-<!ENTITY rustc-openssl-nice           "0.10.78">
-<!ENTITY rustc-openssl-sys-nice       "0.9.114">
+<!ENTITY rustc-change-id              "154587">
 <!ENTITY cbindgen-version             "0.29.4">
 <!ENTITY rust-bindgen-version         "0.72.1">
 <!ENTITY mako-version                 "1.3.12">
@@ -97,7 +94,7 @@
 <!ENTITY apng-version                 "1.6.58">
 <!ENTITY freetype2-version            "2.14.3">
 <!ENTITY harfbuzz-version             "14.2.1">
-<!ENTITY fontconfig-version           "2.18.1">
+<!ENTITY fontconfig-version           "2.18.2">
 <!-- stable lt .90 micro version -->
 <!-- BEGIN X7LIB -->
 <!ENTITY xtrans-version               "1.6.0">
@@ -117,7 +114,7 @@
 <!ENTITY libXcursor-version           "1.2.3">
 <!ENTITY libXdamage-version           "1.1.7">
 <!ENTITY libfontenc-version           "1.1.9">
-<!ENTITY libXfont2-version            "2.0.7">
+<!ENTITY libXfont2-version            "2.0.8">
 <!ENTITY libXft-version               "2.3.9">
 <!ENTITY libXi-version                "1.8.3">
 <!ENTITY libXinerama-version          "1.1.6">
@@ -149,7 +146,7 @@
 <!ENTITY libevdev-version             "1.13.6">
 <!ENTITY libinput-version             "1.31.3">
 <!-- Wayland -->
-<!ENTITY wayland-version              "1.25.0">
+<!ENTITY wayland-version              "1.26.0">
 <!ENTITY wayland-protocols-version    "1.49">
 <!-- Graphics APIs -->
 <!ENTITY libglvnd-version             "1.7.0">
@@ -159,7 +156,7 @@
 <!ENTITY libatomic_ops-version        "7.10.0">
 <!ENTITY libdrm-version               "2.4.134">
 <!ENTITY libgbm-version               "1.0.7">
-<!ENTITY libva-version                "2.24.0">
+<!ENTITY libva-version                "2.24.1">
 <!ENTITY opencl-version               "2026.05.29">
 <!ENTITY libclc-version               "&llvm-version;">
 <!-- Graphics Drivers - Preliminaries -->
@@ -218,23 +215,23 @@
 <!ENTITY xinput-version               "1.6.4">
 <!ENTITY xkbcomp-version              "1.5.0">
 <!ENTITY xkbevd-version               "1.1.6">
-<!ENTITY xkbutils-version             "1.0.6">
+<!ENTITY xkbutils-version             "1.0.7">
 <!ENTITY xkill-version                "1.0.7">
-<!ENTITY xlsatoms-version             "1.1.4">
+<!ENTITY xlsatoms-version             "1.1.5">
 <!ENTITY xlsclients-version           "1.1.6">
 <!ENTITY xmessage-version             "1.0.7">
 <!ENTITY xmodmap-version              "1.0.11">
 <!ENTITY xpr-version                  "1.2.0">
 <!ENTITY xprop-version                "1.2.8">
 <!ENTITY xrandr-version               "1.5.4">
-<!ENTITY xrdb-version                 "1.2.2">
-<!ENTITY xrefresh-version             "1.1.0">
-<!ENTITY xset-version                 "1.2.5">
-<!ENTITY xsetroot-version             "1.1.3">
-<!ENTITY xvinfo-version               "1.1.5">
-<!ENTITY xwd-version                  "1.0.9">
+<!ENTITY xrdb-version                 "1.2.3">
+<!ENTITY xrefresh-version             "1.1.1">
+<!ENTITY xset-version                 "1.2.6">
+<!ENTITY xsetroot-version             "1.1.4">
+<!ENTITY xvinfo-version               "1.1.6">
+<!ENTITY xwd-version                  "1.0.10">
 <!ENTITY xwininfo-version             "1.1.6">
-<!ENTITY xwud-version                 "1.0.7">
+<!ENTITY xwud-version                 "1.0.8">
 <!-- END X7APP -->
 <!ENTITY xcursor-themes-version       "1.0.7">
 <!-- BEGIN X7FONTS -->
@@ -251,8 +248,8 @@
 <!ENTITY xkeyboard-config-version     "2.48">
 <!ENTITY libepoxy-minor               "1.5">
 <!ENTITY libepoxy-version             "&libepoxy-minor;.10">
-<!ENTITY xorg-server-version          "21.1.23">
-<!ENTITY xwayland-version             "24.1.12">
+<!ENTITY xorg-server-version          "21.1.24">
+<!ENTITY xwayland-version             "24.1.13">
 <!-- BEGIN X7DRIVER -->
 <!ENTITY xorg-evdev-driver-version    "2.11.0">
 <!ENTITY xorg-libinput-driver-version "1.5.0">
@@ -267,7 +264,7 @@
 
 <!ENTITY xdg-user-dirs-version        "0.20">
 <!ENTITY libgpg-error-version         "1.61">
-<!ENTITY steam-version                "1.0.0.85">
+<!ENTITY steam-version                "1.0.0.87">
 
 
 
@@ -290,7 +287,7 @@
 
 <!ENTITY nasm-version                 "3.02">
 <!ENTITY svt-av1-version              "4.1.0">
-<!ENTITY dav1d-version                "1.5.3">
+<!ENTITY dav1d-version                "1.5.4">
 <!ENTITY libaom-version               "3.14.1">
 <!ENTITY fdk-aac-version              "2.0.3">
 <!ENTITY lame-version                 "3.100">
@@ -298,7 +295,7 @@
 <!ENTITY x264-version                 "20250815">
 <!ENTITY x265-version                 "4.2">
 <!ENTITY ffmpeg-version               "8.1.2">
-<!ENTITY gstreamer-version            "1.28.4">
+<!ENTITY gstreamer-version            "1.28.5">
 
 <!ENTITY wine-major-version           "11">
 <!ENTITY wine-version                 "&wine-major-version;.12">


### PR DESCRIPTION
NSS:         3.125    -> 3.126.
p11-kit:     0.26.2   -> 0.26.4 (sikkerhet).
libpsl:      0.22.0   -> 0.23.0.
CMake:       4.3.4    -> 4.4.0.
Rustc:       1.96.0   -> 1.97.1.
Fontconfig:  2.18.1   -> 2.18.2.
libXfont2:   2.0.7    -> 2.0.8 (sikkerhet).
Wayland:     1.25.0   -> 1.26.0.
libva:       2.24.0   -> 2.24.1.
xkbutils:    1.0.6    -> 1.0.7.
xlsatoms:    1.1.4    -> 1.1.5.
xrdb:        1.2.2    -> 1.2.3.
xrefresh:    1.1.0    -> 1.1.1.
xset:        1.2.5    -> 1.2.6.
xsetroot:    1.1.3    -> 1.1.4.
xvinfo:      1.1.5    -> 1.1.6.
xwd:         1.0.9    -> 1.1.10.
xwud:        1.0.7    -> 1.0.8.
Xorg-Server: 21.1.23  -> 21.1.24 (sikkerhet).
Xwayland:    24.1.12  -> 24.1.13 (sikkerhet).
Steam:       1.0.0.85 -> 1.0.0.87.
dav1d:       1.5.3    -> 1.5.4.
GStreamer:   1.28.4   -> 1.28.5 (sikkerhet).